### PR TITLE
raise Metrics/BlockLength threshold

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -46,6 +46,10 @@ Metrics/LineLength:
   # Max: 180
   Enabled: false
 
+Metrics/BlockLength:
+  Max: 150
+  CountComments: false
+
 Lint/UnusedBlockArgument:
   Enabled: true
 


### PR DESCRIPTION
デフォルトの 25 は流石にきついけど off にするのもあれなきもするので 150 くらいにしてみました。