### PR TITLE
Metrics/BlockLength から RSpec の関連ファイルは除外した

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -47,6 +47,10 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Max: 150
   CountComments: false
+  # NOTE RSpec のブロックは長くなるため
+  Exclude:
+    - "**/*_spec.rb"
+    - "spec/support/*.rb"
 
 Metrics/ClassLength:
   Max: 1000


### PR DESCRIPTION
RSpec はほとんどがブロックで記述していくため、行数をおさえるのが難しい。