### PR TITLE
Update Delimiter to keep current settings

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -139,6 +139,16 @@ Style/MultilineBlockChain:
 Style/MultilineOperationIndentation:
   Enabled: false
 
+# NOTE () で統一していたため [] への変更はしない
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%r': '{}'
+    '%w': '()'
+    '%W': '()'
+    '%i': '()'
+    '%I': '()'
+
 Style/PredicateName:
   Enabled: false
 


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/issues/4039

上記 PR の通りで、0.48.1 以降、デフォルトが `[]` に変わったが、これまで `()` で統一していたため、既存の設定に合わせる