### PR TITLE
Change Style/CaseIndentation configuration

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -106,6 +106,9 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Enabled: false
 
+Style/CaseIndentation:
+  EnforcedStyle: end
+
 Style/ClassAndModuleChildren:
   Enabled: false
 


### PR DESCRIPTION
```
hoge = case condition
  when 'a'
    'A'
  when 'b'
    'B'
  else
    ''
  end
```

この書き方もあったため、`case` ではなく `end` に合わせるで統一した方が良さそう。