### PR TITLE
Change PreferredDelimiters of "%" from "()" to "||"

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -156,6 +156,7 @@ Style/MultilineBlockChain:
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: ()
+    '%': '||'
     '%r': '{}'
     '%w': '()'
     '%W': '()'


### PR DESCRIPTION
以下のようなケースにおいて、| を利用する習慣があるため。
example)
system %|script|