### PR TITLE
MatchData を使わないときは `=~`  にするのはオフってもよいのではないかと

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -107,6 +107,9 @@ Metrics/PerceivedComplexity:
 NumericLiterals:
   MinDigits: 12
 
+Performance/RedundantMatch:
+  Enabled: false
+
 Rails:
   Enabled: true
 


### PR DESCRIPTION
そこまでパフォーマンスに影響なさそうですし…。
Ruby 2.4 になった暁には `#match?` ができてこちらのほうが効率が良いのでそらなら意味はありそうですが…。