### PR TITLE
`Style/IfUnlessModifier: MaxLineLength` has been removed.

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -155,9 +155,6 @@ Style/EmptyLiteral:
 Style/GuardClause:
   MinBodyLength: 3
 
-Style/IfUnlessModifier:
-  MaxLineLength: 60
-
 Style/Lambda:
   Enabled: false
 


### PR DESCRIPTION
タイトルのとおりですが、いままでは if 行の最大長をチェックしていたのですがこのチェックが削除されました。大体として1行の長さのチェックを使えと言われているのですが、1行の文字数はあまりみやすさに関しては本質的でなくすでに長いところもたくさんあり、これはあまり GEES にはフィットしないのではないかと思い、削除するにとどめ1行の長さチェックはしないほうが良いと思いました。

GuardClauser の処理となんか関係するらしいですがちゃんとは読んでません…。
https://github.com/bbatsov/rubocop/issues/2679

全体に関する話なのでまた開発の定例でトピック共有しますが、CI で失敗してしまうので、ひとまずこれはこれでマージしていただけると 🙇 