### PR TITLE
if ブロックを next で置き換えられるケースのしきい値を変更

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -158,6 +158,10 @@ Style/GuardClause:
 Style/Lambda:
   Enabled: false
 
+Style/Next:
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 10
+
 Style/MultilineBlockChain:
   Enabled: false
 


### PR DESCRIPTION
if-end のブロックが `next` で置き換えられるときに指摘するやつです。
詳細は http://changesworlds.com/2014/12/rubocop-style-next/ このあたりとか。

可読性を阻害する量（これがどの程度かというのは難しいですが…）ぐらいがちょうどよくデフォルトの3行はケースによっては過剰ではないかと。GEES は結構空行が多い文化だったりするので。