### PR TITLE
should be Naming

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -176,7 +176,7 @@ Style/PercentLiteralDelimiters:
     '%i': '()'
     '%I': '()'
 
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 Style/Semicolon:
@@ -188,7 +188,7 @@ Style/SignalException:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-Style/VariableNumber:
+Naming/VariableNumber:
   EnforcedStyle: snake_case
 
 Style/WhenThen:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -104,6 +104,12 @@ Metrics/PerceivedComplexity:
     - "**/*_spec.rb"
     - "spec/support/*.rb"
 
+Naming/PredicateName:
+  Enabled: false
+
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
 NumericLiterals:
   MinDigits: 12
 
@@ -176,9 +182,6 @@ Style/PercentLiteralDelimiters:
     '%i': '()'
     '%I': '()'
 
-Naming/PredicateName:
-  Enabled: false
-
 Style/Semicolon:
   Enabled: false
 
@@ -187,9 +190,6 @@ Style/SignalException:
 
 Style/TrailingUnderscoreVariable:
   Enabled: false
-
-Naming/VariableNumber:
-  EnforcedStyle: snake_case
 
 Style/WhenThen:
   Enabled: false


### PR DESCRIPTION
以下の警告が出るので修正しました。

```
.../pulis-0.1.14/config/rubocop.yml: Style/PredicateName has the wrong namespace - should be Naming
.../pulis-0.1.14/config/rubocop.yml: Style/VariableNumber has the wrong namespace - should be Naming
```