### PR TITLE
メソッドの括弧のCopを追加する

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -196,3 +196,9 @@ Style/WhenThen:
 
 SingleLineMethods:
   Enabled: false
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true


### PR DESCRIPTION
## 目的

- メソッドの括弧についてのCop(コーディングルール)を追加します。
- 以前より、メソッドには括弧をつけるようにするというDSOC Ruby開発チームの暗黙的なルールがあるとの指摘がありましたが、今までどこにも明文化されていなかったようです。なので、Rubocopでチェック対象にするように修正しました。

## 方針

- 基本的にはメソッドに括弧を付けますが、例外として引数なしのメソッドやpやput、DSLには括弧つけないという良い感じのCopです。
- 追加するCop
  - `Style/MethodCallWithoutArgsParentheses`
    - https://github.com/rubocop-hq/ruby-style-guide#method-invocation-parens
  - `Style/DefWithParentheses`
    - https://github.com/rubocop-hq/ruby-style-guide#method-parens

## 影響
- 自分で調査した範囲(EntryとCorporation)で、これらのルールを追加したことによる違反は無かったです。