### PR TITLE
Style/Proc を無効にします、書き方の違いしかないようなのであえてチェックをしなくても良いかなと

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -182,6 +182,9 @@ Style/PercentLiteralDelimiters:
     '%i': '()'
     '%I': '()'
 
+Style/Proc:
+  Enabled: false
+
 Style/Semicolon:
   Enabled: false
 


### PR DESCRIPTION
https://github.com/rubocop-hq/ruby-style-guide#proc

```rb
# bad
p = Proc.new { |n| puts n }

# good
p = proc { |n| puts n }
```

これを無効にします。表記の差でしかなく、動作に全く違いがないので、どちらの書き方でも良いかなと思いました。