### PR TITLE
DSOC 開発全体で使っている Ruby バージョンは 2.5 系なので、 Target Version を書き換えた。

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - config/**/*
     - tmp/**/*
     - log/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   # NOTE 4 系を利用している場合は書き換える
   TargetRailsVersion: 5.0
 

--- a/lib/pulis/version.rb
+++ b/lib/pulis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pulis
-  VERSION = '0.1.15'
+  VERSION = '0.1.16'
 end


### PR DESCRIPTION
https://github.com/eightcard/eight_gees_corporation/pull/1499#discussion_r270794972

上記の通り、 Ruby 2.5 では書けるものの Ruby 2.3 では書けない記述について Sider から警告が発せられています。
DSOC 開発は各チーム Ruby 2.5 系を利用しているはずなので、全体の Ruby Target Version を 2.5 に更新します。

rubygems は本 PR がマージされ次第更新します。