### PR TITLE
Fix error from rubocop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -25,7 +25,7 @@ Layout/AlignParameters:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Layout/IndentationWidth:
@@ -45,10 +45,10 @@ Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
 # NOTE チームで推奨しているスタイルを差異があるため
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Enabled: false
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: false
 
 Lint/UnderscorePrefixedVariableName:


### PR DESCRIPTION
最新版の rubocop 0.68.1 で以下のような Error が出るようになったため修正しました。

```
/tmp/d20190510-15-17d0oqb/vendor/bundle/ruby/2.5.0/gems/pulis-0.1.16/config/rubocop.yml: Lint/BlockAlignment has the wrong namespace - should be Layout
/tmp/d20190510-15-17d0oqb/vendor/bundle/ruby/2.5.0/gems/pulis-0.1.16/config/rubocop.yml: Lint/EndAlignment has the wrong namespace - should be Layout
Error: The `Layout/IndentHash` cop has been renamed to `Layout/IndentFirstHashElement`.
(obsolete configuration found in /tmp/d20190510-15-17d0oqb/vendor/bundle/ruby/2.5.0/gems/pulis-0.1.16/config/rubocop.yml, please update it)
```


