### PR TITLE
add rubocop-rails, rubocop-performance

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -3,6 +3,7 @@
 
 require:
   - rubocop-rails
+  - rubocop-performance
 
 ######## Rubocop Config ########
 AllCops:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,6 +1,9 @@
 # rubocop yml config example
 # https://github.com/ryshinoz/rubocop_sample
 
+require:
+  - rubocop-rails
+
 ######## Rubocop Config ########
 AllCops:
   Exclude:

--- a/lib/pulis/version.rb
+++ b/lib/pulis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pulis
-  VERSION = '0.1.17'
+  VERSION = '0.1.18'
 end

--- a/pulis.gemspec
+++ b/pulis.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.48'
+  spec.add_dependency 'rubocop-rails'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/pulis.gemspec
+++ b/pulis.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 0.48'
   spec.add_dependency 'rubocop-rails'
+  spec.add_dependency 'rubocop-performance'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Rails Cops と Performance Cops が rubocop から外れました。
これらを今まで通り使うには、rubocop-rails, rubocop-performance という gem を入れれば良いのでその対応をしました。