### PR TITLE
rename cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -17,19 +17,19 @@ AllCops:
   # NOTE 4 系を利用している場合は書き換える
   TargetRailsVersion: 5.0
 
-AndOr:
+Style/AndOr:
   Enabled: false
 
-CommentAnnotation:
+Style/CommentAnnotation:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
 Layout/IndentationWidth:
@@ -114,7 +114,7 @@ Naming/PredicateName:
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 
-NumericLiterals:
+Style/NumericLiterals:
   MinDigits: 12
 
 Performance/RedundantMatch:
@@ -135,7 +135,7 @@ Rails/HttpPositionalArguments:
 Rails/Validation:
   Enabled: true
 
-RedundantSelf:
+Style/RedundantSelf:
   Enabled: false
 
 Style/AsciiComments:
@@ -201,7 +201,7 @@ Style/TrailingUnderscoreVariable:
 Style/WhenThen:
   Enabled: false
 
-SingleLineMethods:
+Style/SingleLineMethods:
   Enabled: false
 
 Style/MethodCallWithoutArgsParentheses:

--- a/lib/pulis/version.rb
+++ b/lib/pulis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pulis
-  VERSION = '0.1.18'
+  VERSION = '0.1.19'
 end


### PR DESCRIPTION
以下の waning, error に対応しました。

```
# bundle exec rubocop --display-style-guide --cache=false --format=json --no-display-cop-names
/home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml: Warning: no department given for AndOr.
/home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml: Warning: no department given for CommentAnnotation.
/home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml: Warning: no department given for NumericLiterals.
/home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml: Warning: no department given for RedundantSelf.
/home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml: Warning: no department given for SingleLineMethods.
Error: The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
(obsolete configuration found in /home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml, please update it)
The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in /home/analyzer_runner/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/pulis-0.1.18/config/rubocop.yml, please update it)
```
