### PR TITLE
Metrics/LineLengthのリネーム

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -97,7 +97,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 50
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:


### PR DESCRIPTION
RubocopのMetrics/LineLengthのリネームに対応しました
https://github.com/rubocop-hq/rubocop/pull/7542

rubocopを0.78.0に上げると出てくるエラー:
```
$ bundle exec rubocop --display-style-guide --cache=false --format=json --no-display-cop-names
vendor/bundle/ruby/2.6.0/gems/pulis-0.1.19/config/rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
...
```