### PR TITLE
rubocop 0.80.0にて廃止されたスタイル「Style/BracesAroundHashParameters」を除去

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -144,9 +144,6 @@ Style/AsciiComments:
 Style/BlockDelimiters:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-
 Style/CaseEquality:
   Enabled: false
 

--- a/lib/pulis/version.rb
+++ b/lib/pulis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pulis
-  VERSION = '0.1.20'
+  VERSION = '0.1.30'
 end


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/pull/7643

## 目的
- 本gemに依存する場合、rubocop 80.0以上でも正常に実行されるようにする。

## 方針
- Style/BracesAroundHashParametersに対する設定を除去。

## テスト
- 各プロダクションリポジトリのSiderの正常完了