### PR TITLE
Lint/UselessComparisonの代わりにLint/BinaryOperatorWithIdenticalOperandsを使う

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -74,7 +74,7 @@ Lint/UnusedMethodArgument:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/Void:

--- a/lib/pulis/version.rb
+++ b/lib/pulis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pulis
-  VERSION = '0.1.30'
+  VERSION = '0.1.31'
 end


### PR DESCRIPTION
## 目的
- `Lint/UselessComparison`の代わりに`Lint/BinaryOperatorWithIdenticalOperands`を使用する
- `Lint/UselessComparison`が削除されたようです。