### PR TITLE
fix: follow up rubocop's version-up

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -74,7 +74,7 @@ Lint/UnusedMethodArgument:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/Void:
@@ -176,12 +176,12 @@ Style/MultilineBlockChain:
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: ()
-    '%': '||'
-    '%r': '{}'
-    '%w': '()'
-    '%W': '()'
-    '%i': '()'
-    '%I': '()'
+    "%": "||"
+    "%r": "{}"
+    "%w": "()"
+    "%W": "()"
+    "%i": "()"
+    "%I": "()"
 
 Style/Proc:
   Enabled: false


### PR DESCRIPTION
the rule 'Lint/UselessComparison' is replaced to 'Lint/BinaryOperatorWithIdenticalOperands' in latest rubocop.
(see https://github.com/rubocop-hq/rubocop/releases/tag/v0.89.0)

so, i replaced the rule as above.