### PR TITLE
NewCops: enable

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
   TargetRubyVersion: 2.5
   # NOTE 4 系を利用している場合は書き換える
   TargetRailsVersion: 5.0
+  NewCops: enable
 
 Style/AndOr:
   Enabled: false


### PR DESCRIPTION
新しく追加される cop を都度追加していくのはコストが高いので、デフォルトで enable にしたいです。
rubocop 0.90 からこの指定ができるようになったみたいです。
