### PR TITLE
rubocopのバージョン指定を修正

### DIFF
--- a/pulis.gemspec
+++ b/pulis.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.48'
+  spec.add_dependency 'rubocop'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-performance'
 


### PR DESCRIPTION
rubocopの最新が1.2.0になり、pulisがこれのバージョン指定によってdowngradeしてしまっていたので、バージョン指定を解除します