### PR TITLE
[DIG-GEESER-803] rubocop の バージョンダウン

### DIFF
--- a/lib/pulis/version.rb
+++ b/lib/pulis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pulis
-  VERSION = '0.1.36'
+  VERSION = '0.1.37'
 end

--- a/pulis.gemspec
+++ b/pulis.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '~> 1.62.1'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-performance'
 


### PR DESCRIPTION
## 目的

rubocopが、1.63.0から暗黙的にbundle ファイル全てをインストールすることを前提にしている
そのためバージョンを1.62.1で固定するように
